### PR TITLE
Adding KIOXIA EXCERIA G2 and Juniper EX2200-48P-4G to the supported list

### DIFF
--- a/docs/docs/blade/compatibility/ssd.md
+++ b/docs/docs/blade/compatibility/ssd.md
@@ -39,6 +39,7 @@ Below is a list of NVMe SSDs that have been tested by Uptime Lab and community m
 | KIOXIA-EXCERIA SSD            | LRC10Z500GG8       | 500GB        | [xvzf](https://github.com/xvzf)             |
 | KIOXIA BG4                    | KBG40ZNS128G       | 128GB        | [pxpunx](https://github.com/pxpunx)         |
 | KIOXIA BG5 <sup>1</sup>       | KBG50ZNV512G       | 512GB        | [xvzf](https://github.com/xvzf)             |
+| KIOXIA EXCERIA G2             | LRC20Z002TG8       |   2TB        | [mookie-](https://github.com/mookie-)       |
 
 <sup>1</sup> _Might cause slightly increased CM4 temperature, but stability & performance is not impacted (reported by [xvzf](https://github.com/xvzf)) ._
 

--- a/docs/docs/blade/compatibility/switch.md
+++ b/docs/docs/blade/compatibility/switch.md
@@ -19,3 +19,9 @@ PoE enabled switch & Injectors which have been used with the Compute Blade
 | Product                       | Model Number              | Tested By |
 |:------------------------------|:------------------ | --------- |
 | TL-SG105MPE | [TL-SG105MPE](https://www.tp-link.com/us/home-networking/5-port-switch/tl-sg105mpe/) | slipstickn(On Discord) |
+
+## Juniper
+
+| Product                       | Model Number              | Tested By |
+|:------------------------------|:------------------ | --------- |
+| EX2200-48P-4G | [EX2200-48P-4G](https://www.juniper.net/documentation/product/us/en/ex2200/) | [mookie-](https://github.com/mookie-) |


### PR DESCRIPTION
Adding KIOXIA EXCERIA G2 and Juniper EX2200-48P-4G to the supported list.

Tested both with three beta blades for more than a year.