### PR TITLE
fix links to datasheets and bladerunner models

### DIFF
--- a/docs/docs/blade/heat-sink.mdx
+++ b/docs/docs/blade/heat-sink.mdx
@@ -7,7 +7,7 @@ The aluminum Heat Sink is meticulously engineered to provide maximum heat dissip
 
 <img src="/img/heat-sink/heat-sink.webp" alt="Heat Sink" width={'50%'}/>
 
-[Heat Sink Datasheet](/datasheet/Heatsink_datasheet_v.1.0.pdf) (PDF)
+[Heat Sink Datasheet](/docs/static/datasheet/Heatsink_datasheet_v.1.0.pdf) (PDF)
 
 ## features
 

--- a/docs/docs/blade/index.mdx
+++ b/docs/docs/blade/index.mdx
@@ -20,7 +20,7 @@ import ThemedImage from '@theme/ThemedImage';
     width={"100%"}
 />
 
-Download the [Datasheet](/datasheet/ComputeBlade_datasheet_v.1.1.pdf)
+Download the [Datasheet](/docs/static/docs/static/datasheet/ComputeBlade_datasheet_v.1.1.pdf)
 
 ##  Features and Specifications
 The Compute Blade comes in three different hardware variants.

--- a/docs/docs/bladerunner/19inch/index.mdx
+++ b/docs/docs/bladerunner/19inch/index.mdx
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 The Enterprise 19-Inch Enclosure is for deployment at scale. Can be equipped with twenty Compute Blades and ten Fan Units, offering high density compute in a standard 1U of rack space.
 
-Download the [Datasheet](/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
+Download the [Datasheet](/docs/static/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
 
 ## Drawing
 <img src="/img/bladerunner/19/19-drawing.webp" alt="Drawing with dimensions" width={'100%'}/>

--- a/docs/docs/bladerunner/2node/index.mdx
+++ b/docs/docs/bladerunner/2node/index.mdx
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 2-Node Enclosure allows two Compute Blades and one Fan Unit to be installed. It is ideal for desktop and development.
 
-Download the [Datasheet](/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
+Download the [Datasheet](/docs/static/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
 
 ## Drawing
 <img src="/img/bladerunner/twin/twin-drawing.webp" alt="Drawing with dimensions" width={'100%'}/>

--- a/docs/docs/bladerunner/4node/index.mdx
+++ b/docs/docs/bladerunner/4node/index.mdx
@@ -9,7 +9,7 @@ sidebar_position: 2
 The 4-node BladeRunner™️ is our recommend enclosure for Homelab and cluster development.
 Capable of holding four Compute Blades and two Fan Units, it is ideal for quickly spinning up a development environment.
 
-Download the [Datasheet](/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
+Download the [Datasheet](/docs/static/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
 
 ## Drawing
 

--- a/docs/docs/bladerunner/index.mdx
+++ b/docs/docs/bladerunner/index.mdx
@@ -9,10 +9,10 @@ Engineered to scale and offer the greatest flexibility without the need to spend
 
 3D Models for all three Blade Enclosures can be found on our [GitHub](https://github.com/uptime-industries/compute-blade/tree/main/bladerunner).
 
-[Datasheet](/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
+[Datasheet](/docs/static/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
 
 ## Models
 
-- [19-inch 1U Rack](/bladerunner/19inch) - 19" Rack enclosure for up to 20 Compute Blades 
-- [4-node](/bladerunner/4node) - Ideal enclosure for Homelab or cluster development containing up to 4 Compute Blades
-- [2-node](/bladerunner/2node) - Small enclosure for up to 2 Compute Blades
+- [19-inch 1U Rack](/models/bladerunner/19-inch) - 19" Rack enclosure for up to 20 Compute Blades
+- [4-node](/models/bladerunner/quad) - Ideal enclosure for Homelab or cluster development containing up to 4 Compute Blades
+- [2-node](/models/bladerunner/twin) - Small enclosure for up to 2 Compute Blades

--- a/docs/docs/fan-unit/index.mdx
+++ b/docs/docs/fan-unit/index.mdx
@@ -19,7 +19,7 @@ import ThemedImage from '@theme/ThemedImage';
 />
 <sub>*Smart Fan Unit Pictured Above*</sub>
 
-Download the [Datasheet](/datasheet/FanUnit_datasheet_v.1.0.pdf)
+Download the [Datasheet](/docs/static/datasheet/FanUnit_datasheet_v.1.0.pdf)
 
 ## Fan Units
 

--- a/docs/src/pages/datasheets.md
+++ b/docs/src/pages/datasheets.md
@@ -1,9 +1,9 @@
 # Data sheets
 
-[Compute Blade v.1.1](/datasheet/ComputeBlade_datasheet_v.1.1.pdf) (PDF)
+[Compute Blade v.1.1](/docs/static/datasheet/ComputeBlade_datasheet_v.1.1.pdf) (PDF)
 
-[Fan Unit v.1.0](/datasheet/FanUnit_datasheet_v.1.0.pdf) (PDF)
+[Fan Unit v.1.0](/docs/static/datasheet/FanUnit_datasheet_v.1.0.pdf) (PDF)
 
-[BladeRunner™️ v.1.0](/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
+[BladeRunner™️ v.1.0](/docs/static/datasheet/BladeRunner_datasheet_v.1.0.pdf) (PDF)
 
-[Heatsink v.1.0](/datasheet/Heatsink_datasheet_v.1.0.pdf) (PDF)
+[Heatsink v.1.0](/docs/static/datasheet/Heatsink_datasheet_v.1.0.pdf) (PDF)


### PR DESCRIPTION
I've noticed the links to the 3d models and datasheets weren't correct.